### PR TITLE
Api authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ Forkinfo takes a single argument, and that's the `user/repo` string. For example
 ```
 $ forkinfo dshoreman/forkinfo
 ```
+
+When you run Forkinfo you will be prompted to enter a Personal Access Token to avoid hitting rate
+limits on the Github API. This is optional, but will be saved to a config file once you paste in your
+token and hit enter. To skip authentication, run Forkinfo with the `--no-token` flag. Note that "guest"
+API access is limited to 60 requests per hour, which may be too low for some repositories.

--- a/forkinfo.go
+++ b/forkinfo.go
@@ -56,9 +56,14 @@ func setupAPI() {
 
 func promptForToken() {
     reader := bufio.NewReader(os.Stdin)
+    fmt.Println("The Github API limits Unauthenticated access to 60 requests per")
+    fmt.Println("hour. To raise these limits, create a Personal Access Token at")
+    fmt.Println("https://github.com/settings/tokens/new?description=Forkinfo.")
+    fmt.Println("Leaves scopes unchecked - Forkinfo requires no special access.")
+    fmt.Println()
 
     for prompt := true; prompt; prompt = token == "" {
-        fmt.Println("Paste your API key to authenticate:")
+        fmt.Println("Paste your API key below:")
         token, _ = reader.ReadString('\n')
         token = strings.Trim(token, " \n\r\t")
     }

--- a/forkinfo.go
+++ b/forkinfo.go
@@ -81,16 +81,14 @@ func promptForToken() {
     fmt.Println("hour. To raise these limits, create a Personal Access Token at")
     fmt.Println("https://github.com/settings/tokens/new?description=Forkinfo.")
     fmt.Println("Leaves scopes unchecked - Forkinfo requires no special access.")
+    fmt.Println("To run without authentication, use forkinfo with `--no-token`.")
     fmt.Println()
-    fmt.Println("To continue unauthenticated, press Enter. To use your newly")
-    fmt.Println("newly created Personal Access Token, first paste it below:")
 
     reader := bufio.NewReader(os.Stdin)
-    token, _ := reader.ReadString('\n')
-    config.AccessToken = strings.Trim(token, " \n\r\t")
-
-    if config.AccessToken == "" {
-        skipAuth = true
+    for config.AccessToken == "" {
+        fmt.Println("Paste your personal access token:")
+        token, _ := reader.ReadString('\n')
+        config.AccessToken = strings.Trim(token, " \r\n\t")
     }
 }
 

--- a/forkinfo.go
+++ b/forkinfo.go
@@ -32,14 +32,17 @@ var (
 )
 
 func loadConfig() {
-    data, err := ioutil.ReadFile(strings.Join([] string {
+    file := strings.Join([] string {
         os.Getenv("HOME"),
         configPath,
         configFile,
-    }, "/"))
-    abortOnError(err)
+    }, "/")
 
-    json.Unmarshal(data, &config)
+    if data, err := ioutil.ReadFile(file); err == nil {
+        json.Unmarshal(data, &config)
+    } else if !os.IsNotExist(err) {
+        abortOnError(err)
+    }
 }
 
 func setupAPI() {

--- a/forkinfo.go
+++ b/forkinfo.go
@@ -16,10 +16,11 @@ const version = "0.1.0"
 
 var (
     client = github.NewClient(nil)
+    ctx = context.Background()
 )
 
 func fetchRepository(username, repository string) (repo *github.Repository) {
-    repo, _, err := client.Repositories.Get(context.Background(), username, repository)
+    repo, _, err := client.Repositories.Get(ctx, username, repository)
     abortOnError(err)
     return
 }
@@ -28,7 +29,7 @@ func fetchRepositoryForks(repo *github.Repository) (forks []*github.Repository) 
     opts := github.RepositoryListForksOptions{
         ListOptions: github.ListOptions{PerPage: repo.GetForksCount()},
     }
-    forks, _, err := client.Repositories.ListForks(context.Background(), *repo.Owner.Login, *repo.Name, &opts)
+    forks, _, err := client.Repositories.ListForks(ctx, *repo.Owner.Login, *repo.Name, &opts)
     abortOnError(err)
     return
 }


### PR DESCRIPTION
Attempts to read a personal access token from `~/.config/forkinfo/config.json` and uses it to authenticate with the API to avoid running into rate limits.

If a config file can't be found, it will instead prompt the user to paste their key in at runtime.