### PR TITLE
Hide mirrors from list of forks

### DIFF
--- a/forkinfo.go
+++ b/forkinfo.go
@@ -117,6 +117,7 @@ func main() {
     fmt.Printf("Listing forks of %s...\n\n", *repo.FullName)
     forks := fetchRepositoryForks(repo)
     numBad := 0
+    numOld := 0
     numDupes := 0
     numForks := len(forks)
 
@@ -137,6 +138,10 @@ func main() {
             numDupes++
             continue
         }
+        if comp.GetStatus() == "behind" {
+            numOld++
+            continue
+        }
 
         fmt.Printf("%s %s\n", rowNum(i+1, numForks), *fork.FullName)
         fmt.Printf(
@@ -149,7 +154,7 @@ func main() {
         printRepoStats(fork, "short")
     }
 
-    fmt.Printf("Fork listing complete with %d mirror(s) hidden and %d with errors.\n", numDupes, numBad)
+    fmt.Printf("Fork listing complete. Hidden %d mirrors, %d outdated and %d broken forks.\n", numDupes, numOld, numBad)
 }
 
 func init() {

--- a/forkinfo.go
+++ b/forkinfo.go
@@ -116,15 +116,19 @@ func main() {
 
     fmt.Printf("Listing forks of %s...\n\n", *repo.FullName)
     forks := fetchRepositoryForks(repo)
+    numDupes := 0
     numForks := len(forks)
 
     for i, fork := range forks {
         if fork.PushedAt.Equal(*repo.PushedAt) {
+            numDupes++
             continue
         }
         fmt.Printf("%s %s\n", rowNum(i+1, numForks), *fork.FullName)
         printRepoStats(fork, "short")
     }
+
+    fmt.Printf("Fork listing complete with %d mirror(s) hidden.\n", numDupes)
 }
 
 func init() {

--- a/forkinfo.go
+++ b/forkinfo.go
@@ -119,6 +119,9 @@ func main() {
     numForks := len(forks)
 
     for i, fork := range forks {
+        if fork.PushedAt.Equal(*repo.PushedAt) {
+            continue
+        }
         fmt.Printf("%s %s\n", rowNum(i+1, numForks), *fork.FullName)
         printRepoStats(fork, "short")
     }


### PR DESCRIPTION
Removes forks from the output when their most recent push time matches that of the parent repo.

Closes #4